### PR TITLE
Helm/optional internal secret

### DIFF
--- a/helm/resurfaceio/resurface/Chart.yaml
+++ b/helm/resurfaceio/resurface/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: resurface
-version: 3.2.2
+version: 3.2.3
 type: application
 description: Resurface discovers and alerts on quality and security signatures in your API traffic.
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade network-sniffer image to 1.2.3
+      description: Make Trino's internal comms shared secret available in configmap only when TLS is enabled.
 keywords:
   - API
   - HTTP

--- a/helm/resurfaceio/resurface/templates/_helpers.tpl
+++ b/helm/resurfaceio/resurface/templates/_helpers.tpl
@@ -88,8 +88,10 @@ Default options: container resources and persistent volumes
 Common config.properties for both coordinator and workers
 */}}
 {{- define "resurface.config.common" -}}
-internal-communication.shared-secret={{ randAscii 32 | b64enc }}
 http-server.http.port=7700
+{{ if and .Values.ingress.enabled .Values.ingress.tls.enabled -}}
+internal-communication.shared-secret={{ randAscii 32 | b64enc }}
+{{- end }}
 
 query.max-history=20
 query.max-length=1000000


### PR DESCRIPTION
- This PR changes the injection of the `internal-communication.shared.secret` property so that it happens only when TLS is enabled. This way internal queries are enabled by default.
- Chart version and changelog have been updated accordingly.